### PR TITLE
Added color gain controls, changed 'brightness' to 'luminance', updated help/README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You can then run the app by entering:
 
 ## Commands:
 
-`set luminance n ` - Sets luminance ("brightness") to n, where n is a number between 0 and the maximum value (usually 100).
+`set luminance n` - Sets luminance ("brightness") to n, where n is a number between 0 and the maximum value (usually 100).
 
 `set contrast n` - Sets contrast to n, where n is a number between 0 and the maximum value (usually 100).
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ You can then run the app by entering:
 
 `m1ddc set contrast 5` - Sets contrast to 5 on default display
 
-`m1ddc get brightness` - Returns current brightness on default display
+`m1ddc get luminance` - Returns current luminance ("brightness") on default display
+
+`m1ddc set red 90` - Sets red gain to 90
 
 `m1ddc chg volume -10` - Decreases volume by 10 on default display
 
@@ -30,33 +32,44 @@ You can then run the app by entering:
 
 `m1ddc display 1 set volume 50` - Sets volume to 50 on Display 1
 
-## Paramteres:
+## Commands:
 
-`set brightness n ` - Sets brightness to n, where n is a number between 0 and the maximum value (usually 100).
+`set luminance n ` - Sets luminance ("brightness") to n, where n is a number between 0 and the maximum value (usually 100).
 
 `set contrast n` - Sets contrast to n, where n is a number between 0 and the maximum value (usually 100).
 
+`set (red,green,blue) n` - Sets selected color channel gain to n, where n is a number between 0 and the maximum value (usually 100).
+
 `set volume n` - Sets volume to n, where n is a number between 0 and the maximum value (usually 100).
+
+`set input n` - Sets input source to n, common values include:<br/>
+DisplayPort 1: 15, DisplayPort 2: 16, HDMI 1: 17 HDMI 2: 18, USB-C: 27.
 
 `set mute on` - Sets mute on (you can use 1 instead of 'on')
 
 `set mute off` - Sets mute off (you can use 2 instead of 'off')
 
-`get brightness` - Returns current brightness (if supported by the display).
+`get luminance` - Returns current luminance (if supported by the display).
 
 `get contrast` - Returns current contrast (if supported by the display).
 
+`get (red,green,blue)` - Returns current color gain (if supported by the display).
+
 `get volume` - Returns current volume (if supported by the display).
 
-`max brightness` - Returns maximum brightness (if supported by the display, usually 100).
+`max luminance` - Returns maximum luminance (if supported by the display, usually 100).
 
 `max contrast` - Returns maximum contrast (if supported by the display, usually 100).
 
+`max (red,green,blue)` - Returns maximum color gain (if supported by the display, usually 100).
+
 `max volume` - Returns maximum volume (if supported by the display, usually 100).
 
-`chg brightness n` - Changes brightness by n and returns the current value (requires current and max reading support).
+`chg luminance n` - Changes luminance by n and returns the current value (requires current and max reading support).
 
 `chg contrast n` - Changes contrast by n and returns the current value (requires current and max reading support).
+
+`chg (red,green,blue) n` - Changes color gain by n and returns the current value (requires current and max reading support).
 
 `chg volume n` - Changes volume by n and returns the current value (requires current and max reading support).
 
@@ -64,14 +77,15 @@ You can then run the app by entering:
 
 `display n` - Chooses which display to control (use number 1, 2 etc.)
 
-You can also use 'b', 'c' and 'v' instead of 'brightness', 'contrast', 'volume'.
+You can also use 'l', 'v' instead of 'luminance', 'volume' etc.
 
 ## Example use in a script
 
-Check out the following [hammerspoon](https://github.com/Hammerspoon/hammerspoon) script. 
+Check out the following [hammerspoon](https://github.com/Hammerspoon/hammerspoon) script.
 
 This script allows you to control the volume of your external Display' brightness, contrast and volume via DDC (if you use an M1 Mac) using [m1ddc](https://github.com/waydabber/m1ddc) and also control your Yamaha AV Receiver through network. The script listens to the standard Apple keyboard media keys and shos the standard macOS Birghtness and Volume OSDs via uses [showosd](https://github.com/waydabber/showosd) :
 
+(Uses old 'brightness' term instead of 'luminance')
 https://gist.github.com/waydabber/3241fc146cef65131a42ce30e4b6eab7
 
 ## Thanks

--- a/m1ddc.m
+++ b/m1ddc.m
@@ -48,17 +48,17 @@ int main(int argc, char** argv) {
     " set mute on             - Sets mute on (you can use 1 instead of 'on')\n"
     " set mute off            - Sets mute off (you can use 2 instead of 'off')\n"
     "\n"
-    " get luminance          - Returns current luminance (if supported by the display).\n"
+    " get luminance           - Returns current luminance (if supported by the display).\n"
     " get contrast            - Returns current contrast (if supported by the display).\n"
     " get (red,green,blue)    - Returns current color gain (if supported by the display).\n"
     " get volume              - Returns current volume (if supported by the display).\n"
     "\n"
-    " max luminance         - Returns maximum luminance (if supported by the display, usually 100).\n"
+    " max luminance           - Returns maximum luminance (if supported by the display, usually 100).\n"
     " max contrast            - Returns maximum contrast (if supported by the display, usually 100).\n"
     " max (red,green,blue)    - Returns maximum color gain (if supported by the display, usually 100).\n"
     " max volume              - Returns maximum volume (if supported by the display, usually 100).\n"
     "\n"
-    " chg luminance n        - Changes luminance by n and returns the current value (requires current and max reading support).\n"
+    " chg luminance n         - Changes luminance by n and returns the current value (requires current and max reading support).\n"
     " chg contrast n          - Changes contrast by n and returns the current value (requires current and max reading support).\n"
     " chg (red,green,blue) n  - Changes color gain by n and returns the current value (requires current and max reading support).\n"
     " chg volume n            - Changes volume by n and returns the current value (requires current and max reading support).\n"
@@ -182,7 +182,6 @@ int main(int argc, char** argv) {
         else if ( !(strcmp(argv[s+2], "red")) || !(strcmp(argv[s+2], "r")) ) { data[2] = RED; }
         else if ( !(strcmp(argv[s+2], "green")) || !(strcmp(argv[s+2], "g")) ) { data[2] = GREEN; }
         else if ( !(strcmp(argv[s+2], "blue")) || !(strcmp(argv[s+2], "b")) ) { data[2] = BLUE; }
-        else if ( !(strcmp(argv[s+2], "satblue")) ) { data[2] = SAT_BLUE; }
         else {
 
             returnText = @"Use 'luminance', 'contrast', 'volume' or 'mute' as second parameter! Enter 'm1ddc help' for help!\n";

--- a/m1ddc.m
+++ b/m1ddc.m
@@ -14,9 +14,9 @@ extern IOReturn IOAVServiceWriteI2C(IOAVServiceRef service, uint32_t chipAddress
 #define MUTE 0x8D
 #define INPUT 0x60
 #define STANDBY 0xD6
-#define RED 0x16 // VCP Code: Video Gain (Drive): Red
-#define GREEN 0x18 // VCP Code: Video Gain (Drive): Green
-#define BLUE 0x1A // VCP Code: Video Gain (Drive): Blue
+#define RED 0x16 // VCP Code - Video Gain (Drive): Red
+#define GREEN 0x18 // VCP Code - Video Gain (Drive): Green
+#define BLUE 0x1A // VCP Code - Video Gain (Drive): Blue
 
 #define DDC_WAIT 10000 // depending on display this must be set to as high as 50000
 #define DDC_ITERATIONS 2 // depending on display this must be set higher
@@ -28,12 +28,13 @@ int main(int argc, char** argv) {
     NSString *returnText =@"Controls volume, luminance (brightness), contrast, color gain, input of a single external Display connected via USB-C (DisplayPort Alt Mode) over DDC on an M1 Mac.\n"
     "Control of displays attached via the HDMI port or by other means is not currently supported.\n"
     "\n"
-    "Example usages:\n"
+    "Usage examples:\n"
     "\n"
     " m1ddc set contrast 5          - Sets contrast to 5\n"
     " m1ddc get luminance           - Returns current luminance\n"
     " m1ddc set red 90              - Sets red gain to 90\n"
     " m1ddc chg volume -10          - Decreases volume by 10\n"
+    " m1ddc display list            - Lists displays\n"
     " m1ddc display 1 set volume 50 - Sets volume to 50 on Display 1\n"
     "\n"
     "Commands:\n"

--- a/m1ddc.m
+++ b/m1ddc.m
@@ -8,73 +8,81 @@ extern IOAVServiceRef IOAVServiceCreateWithService(CFAllocatorRef allocator, io_
 extern IOReturn IOAVServiceReadI2C(IOAVServiceRef service, uint32_t chipAddress, uint32_t offset, void* outputBuffer, uint32_t outputBufferSize);
 extern IOReturn IOAVServiceWriteI2C(IOAVServiceRef service, uint32_t chipAddress, uint32_t dataAddress, void* inputBuffer, uint32_t inputBufferSize);
 
-#define BRIGHTNESS 0x10
+#define LUMINANCE 0x10
 #define CONTRAST 0x12
 #define VOLUME 0x62
 #define MUTE 0x8D
 #define INPUT 0x60
 #define STANDBY 0xD6
+#define RED 0x16 // VCP Code: Video Gain (Drive): Red
+#define GREEN 0x18 // VCP Code: Video Gain (Drive): Green
+#define BLUE 0x1A // VCP Code: Video Gain (Drive): Blue
 
 #define DDC_WAIT 10000 // depending on display this must be set to as high as 50000
 #define DDC_ITERATIONS 2 // depending on display this must be set higher
 
 int main(int argc, char** argv) {
-    
+
     IOAVServiceRef avService;
-    
-    NSString *returnText =@"Controls volume, brightness, contrast, input of a single external Display connected via USB-C (DisplayPort Alt Mode) over DDC on an M1 Mac.\n"
+
+    NSString *returnText =@"Controls volume, luminance (brightness), contrast, color gain, input of a single external Display connected via USB-C (DisplayPort Alt Mode) over DDC on an M1 Mac.\n"
     "Control of displays attached via the HDMI port or by other means is not currently supported.\n"
     "\n"
     "Example usages:\n"
     "\n"
     " m1ddc set contrast 5          - Sets contrast to 5\n"
-    " m1ddc get brightness          - Returns current brightness\n"
+    " m1ddc get luminance           - Returns current luminance\n"
+    " m1ddc set red 90              - Sets red gain to 90\n"
     " m1ddc chg volume -10          - Decreases volume by 10\n"
     " m1ddc display 1 set volume 50 - Sets volume to 50 on Display 1\n"
     "\n"
     "Commands:\n"
     "\n"
-    " set brightness n - Sets brightness to n, where n is a number between 0 and the maximum value (usually 100).\n"
-    " set contrast n   - Sets contrast to n, where n is a number between 0 and the maximum value (usually 100).\n"
-    " set volume n     - Sets volume to n, where n is a number between 0 and the maximum value (usually 100).\n"
-    " set input n      - Sets input source to n, common values include:\n"
-    "                    DisplayPort 1: 15, DisplayPort 2: 16, HDMI 1: 17 HDMI 2: 18, USB-C: 27.\n"
+    " set luminance n         - Sets luminance (brightness) to n, where n is a number between 0 and the maximum value (usually 100).\n"
+    " set contrast n          - Sets contrast to n, where n is a number between 0 and the maximum value (usually 100).\n"
+    " set (red,green,blue) n  - Sets selected color channel gain to n, where n is a number between 0 and the maximum value (usually 100).\n"
+    " set volume n            - Sets volume to n, where n is a number between 0 and the maximum value (usually 100).\n"
+    " set input n             - Sets input source to n, common values include:\n"
+    "                           DisplayPort 1: 15, DisplayPort 2: 16, HDMI 1: 17 HDMI 2: 18, USB-C: 27.\n"
     "\n"
-    " set mute on      - Sets mute on (you can use 1 instead of 'on')\n"
-    " set mute off     - Sets mute off (you can use 2 instead of 'off')\n"
+    " set mute on             - Sets mute on (you can use 1 instead of 'on')\n"
+    " set mute off            - Sets mute off (you can use 2 instead of 'off')\n"
     "\n"
-    " get brightness   - Returns current brightness (if supported by the display).\n"
-    " get contrast     - Returns current contrast (if supported by the display).\n"
-    " get volume       - Returns current volume (if supported by the display).\n"
+    " get luminance          - Returns current luminance (if supported by the display).\n"
+    " get contrast            - Returns current contrast (if supported by the display).\n"
+    " get (red,green,blue)    - Returns current color gain (if supported by the display).\n"
+    " get volume              - Returns current volume (if supported by the display).\n"
     "\n"
-    " max brightness   - Returns maximum brightness (if supported by the display, usually 100).\n"
-    " max contrast     - Returns maximum contrast (if supported by the display, usually 100).\n"
-    " max volume       - Returns maximum volume (if supported by the display, usually 100).\n"
+    " max luminance         - Returns maximum luminance (if supported by the display, usually 100).\n"
+    " max contrast            - Returns maximum contrast (if supported by the display, usually 100).\n"
+    " max (red,green,blue)    - Returns maximum color gain (if supported by the display, usually 100).\n"
+    " max volume              - Returns maximum volume (if supported by the display, usually 100).\n"
     "\n"
-    " chg brightness n - Changes brightness by n and returns the current value (requires current and max reading support).\n"
-    " chg contrast n   - Changes contrast by n and returns the current value (requires current and max reading support).\n"
-    " chg volume n     - Changes volume by n and returns the current value (requires current and max reading support).\n"
+    " chg luminance n        - Changes luminance by n and returns the current value (requires current and max reading support).\n"
+    " chg contrast n          - Changes contrast by n and returns the current value (requires current and max reading support).\n"
+    " chg (red,green,blue) n  - Changes color gain by n and returns the current value (requires current and max reading support).\n"
+    " chg volume n            - Changes volume by n and returns the current value (requires current and max reading support).\n"
     "\n"
-    " display list     - Lists displays.\n"
-    " display n        - Chooses which display to control (use number 1, 2 etc.)\n"
+    " display list            - Lists displays.\n"
+    " display n               - Chooses which display to control (use number 1, 2 etc.)\n"
     "\n"
-    "You can also use 'b', 'v' instead of 'brightness', 'volume' etc.\n"
+    "You can also use 'l', 'v' instead of 'luminance', 'volume' etc.\n"
     ;
     int returnValue = 1;
-    
+
     if (argc >= 3) {
 
         // Display lister and selection
-        
+
         int s=0; // Indicate the presence of display selection (+ messy argument shifter...)
 
         if ( !(strcmp(argv[s+1], "display")) ) {
-            
+
             io_iterator_t iter;
             io_service_t service = 0;
             io_registry_entry_t root = IORegistryGetRootEntry(kIOMasterPortDefault);
             kern_return_t kerr = IORegistryEntryCreateIterator(root, "IOService", kIORegistryIterateRecursively, &iter);
-            
+
             if (kerr != KERN_SUCCESS) {
                 IOObjectRelease(iter);
                 returnText = [NSString stringWithFormat:@"Error on IORegistryEntryCreateIterator: %d", kerr];
@@ -87,10 +95,10 @@ int main(int argc, char** argv) {
             CFStringRef externalAVServiceLocation = CFStringCreateWithCString(kCFAllocatorDefault, "External", kCFStringEncodingASCII);
 
             returnText = @"";
-            
+
             int i=1;
             bool noMatch = true;
-            
+
             while ((service = IOIteratorNext(iter)) != MACH_PORT_NULL) {
                 io_name_t name;
                 IORegistryEntryGetName(service, name);
@@ -101,9 +109,9 @@ int main(int argc, char** argv) {
                     if ( !(edidUUID == NULL) ) {
 
                         if ( !(strcmp(argv[s+2], "list")) || !(strcmp(argv[s+2], "l")) ) {
-                        
+
                             CFDictionaryRef displayAttrs = IORegistryEntrySearchCFProperty(service, kIOServicePlane, displayAttributesKey, kCFAllocatorDefault, kIORegistryIterateRecursively);
-                                                    
+
                             if (displayAttrs ) {
                                 NSDictionary* displayAttrsNS = (NSDictionary*)displayAttrs;
                                 NSDictionary* productAttrs = [displayAttrsNS objectForKey:@"ProductAttributes"];
@@ -112,18 +120,18 @@ int main(int argc, char** argv) {
                                 }
                             }
                             returnText = [NSString stringWithFormat:@"%@ (%@)\n", returnText, edidUUID];
-    
+
                         }
-                        
+
                         if ( atoi(argv[s+2]) == i ) {
-                            
+
                             s=2;
-                            
+
                             while ((service = IOIteratorNext(iter)) != MACH_PORT_NULL) {
                                 io_name_t name;
                                 IORegistryEntryGetName(service, name);
                                 if ( !strcmp(name, "DCPAVServiceProxy") ) {
-                                
+
                                     avService = IOAVServiceCreateWithService(kCFAllocatorDefault, service);
                                     CFStringRef location = IORegistryEntrySearchCFProperty(service, kIOServicePlane, locationKey, kCFAllocatorDefault, kIORegistryIterateRecursively);
 
@@ -134,84 +142,88 @@ int main(int argc, char** argv) {
                                 }
                             }
                         }
-                        
+
                         i++;
-                        
+
                     }
                 }
             }
 
             if ( !(strcmp(argv[s+2], "list")) || !(strcmp(argv[s+2], "l")) ) {
-            
+
                 returnValue = 0;
                 goto cya;
-                
+
             } else if ( noMatch ) {
-                
+
                 returnText = @"The specified display does not exist. Use 'display list' to list displays and use it's number (1, 2...) to specify display!\n";
                 returnValue = 0;
                 goto cya;
 
             }
-            
+
         } else {
-            
+
             avService = IOAVServiceCreate(kCFAllocatorDefault);
-            
+
         }
-        
+
         // Get ready for DDC operations
-        
+
         UInt8 data[256];
         memset(data, 0, sizeof(data));
 
-        if ( !(strcmp(argv[s+2], "brightness")) || !(strcmp(argv[s+2], "b")) ) { data[2] = BRIGHTNESS; }
+        if ( !(strcmp(argv[s+2], "luminance")) || !(strcmp(argv[s+2], "l")) ) { data[2] = LUMINANCE; }
         else if ( !(strcmp(argv[s+2], "contrast")) || !(strcmp(argv[s+2], "c"))  ) { data[2] = CONTRAST; }
         else if ( !(strcmp(argv[s+2], "volume")) || !(strcmp(argv[s+2], "v"))  ) { data[2] = VOLUME; }
         else if ( !(strcmp(argv[s+2], "mute")) || !(strcmp(argv[s+2], "m"))  ) { data[2] = MUTE; }
         else if ( !(strcmp(argv[s+2], "input")) || !(strcmp(argv[s+2], "i"))  ) { data[2] = INPUT; }
         else if ( !(strcmp(argv[s+2], "standby")) || !(strcmp(argv[s+2], "s"))  ) { data[2] = STANDBY; }
+        else if ( !(strcmp(argv[s+2], "red")) || !(strcmp(argv[s+2], "r")) ) { data[2] = RED; }
+        else if ( !(strcmp(argv[s+2], "green")) || !(strcmp(argv[s+2], "g")) ) { data[2] = GREEN; }
+        else if ( !(strcmp(argv[s+2], "blue")) || !(strcmp(argv[s+2], "b")) ) { data[2] = BLUE; }
+        else if ( !(strcmp(argv[s+2], "satblue")) ) { data[2] = SAT_BLUE; }
         else {
-            
-            returnText = @"Use 'brightness', 'contrast', 'volume' or 'mute' as second parameter! Enter 'm1ddc help' for help!\n";
+
+            returnText = @"Use 'luminance', 'contrast', 'volume' or 'mute' as second parameter! Enter 'm1ddc help' for help!\n";
             goto cya;
-            
+
         }
 
         signed char curValue=-1;
         signed char maxValue=-1;
-        
+
         IOReturn err;
-        
+
         if (!avService) {
-            
+
             returnText = @"Could not find a suitable external display.\n";
             goto cya;
-            
+
         }
-        
+
         // Read stuff
-        
+
         if ( !(strcmp(argv[s+1], "get")) || !(strcmp(argv[s+1], "max")) || !(strcmp(argv[s+1], "chg")) ) {
 
             data[0] = 0x82;
             data[1] = 0x01;
             data[3] = 0x6e ^ data[0] ^ data[1] ^ data[2] ^ data[3];
-            
+
             for (int i = 0; i < DDC_ITERATIONS; ++i) {
-                
+
                 usleep(DDC_WAIT);
                 err = IOAVServiceWriteI2C(avService, 0x37, 0x51, data, 4);
-                
+
                 if (err) {
-                    
+
                     returnText = [NSString stringWithFormat:@"I2C communication failure: %s\n", mach_error_string(err)];
                     goto cya;
-                    
+
                 }
-                
+
             }
-                
+
             char i2cBytes[12];
             memset(i2cBytes, 0, sizeof(i2cBytes));
 
@@ -219,17 +231,17 @@ int main(int argc, char** argv) {
             err = IOAVServiceReadI2C(avService, 0x37, 0x51, i2cBytes, 12);
 
             if (err) {
-                
+
                 returnText = [NSString stringWithFormat:@"I2C communication failure: %s\n", mach_error_string(err)];
                 goto cya;
-                
+
             }
-            
+
             NSData *readData = [NSData dataWithBytes:(const void *)i2cBytes length:(NSUInteger)11];
-            
+
             NSRange maxValueRange = {7, 1};
             NSRange currentValueRange = {9, 1};
-            
+
             [[readData subdataWithRange:maxValueRange] getBytes:&maxValue length:sizeof(1)];
             [[readData subdataWithRange:currentValueRange] getBytes:&curValue length:sizeof(1)];
 
@@ -240,58 +252,58 @@ int main(int argc, char** argv) {
                 goto cya;
 
             } else if ( !(strcmp(argv[s+1], "max")) ) {
-                
+
                 returnText = [NSString stringWithFormat:@"%i\n", maxValue];
                 returnValue = 0;
                 goto cya;
 
             }
-        
+
         }
 
         // Set stuff
-        
+
         if ( !(strcmp(argv[s+1], "set")) || !(strcmp(argv[s+1], "chg")) ) {
-            
+
             if (argc != s+4) {
-                
+
                 returnText = [NSString stringWithFormat:@"Missing value! Enter 'm1ddc help' for help!\n"];
                 goto cya;
 
             }
-            
+
             int setValue;
-            
+
             if ( !(strcmp(argv[s+3], "on")) ) { setValue=1; }
             else if ( !(strcmp(argv[s+3], "off")) ) { setValue=2; }
             else { setValue = atoi(argv[s+3]); }
-            
+
             if ( !(strcmp(argv[s+1], "chg")) ) {
-                
+
                 setValue = curValue + setValue;
                 if (setValue < 0 ) { setValue=0; }
                 if (setValue > maxValue ) { setValue=maxValue; }
 
             }
-            
+
             data[0] = 0x84;
             data[1] = 0x03;
             data[3] = (setValue) >> 8;
             data[4] = setValue & 255;
             data[5] = 0x6E ^ 0x51 ^ data[0] ^ data[1] ^ data[2] ^ data[3] ^ data[4];
-            
+
             for (int i = 0; i <= DDC_ITERATIONS; i++) {
-                
+
                 usleep(DDC_WAIT);
                 err = IOAVServiceWriteI2C(avService, 0x37, 0x51, data, 6);
-                
+
                 if (err) {
-                    
+
                     returnText = [NSString stringWithFormat:@"I2C communication failure: %s\n", mach_error_string(err)];
                     goto cya;
-                    
+
                 }
-                
+
             }
 
             if ( !(strcmp(argv[s+1], "chg")) ) {
@@ -301,22 +313,22 @@ int main(int argc, char** argv) {
                 goto cya;
 
             } else {
-            
+
                 returnText = @"";
                 returnValue = 0;
                 goto cya;
-                
+
             }
-            
+
         }
-            
+
         returnText = @"Use 'set', 'get', 'max', 'chg' as first parameter! Enter 'm1ddc help' for help!\n";
         goto cya;
-            
+
     }
-    
+
     cya:
-        
+
     [returnText writeToFile:@"/dev/stdout" atomically:NO encoding:NSUTF8StringEncoding error:nil];
     return returnValue;
 


### PR DESCRIPTION
Based on the availabe [MCCS VCP Codes](https://app.box.com/s/vcocw3z73ta09txiskj7cnk6289j356b/folder/11133466934) (Quick summary here: https://www.ddcutil.com/getvcp_known_u3011_output/), I added three commands for adjusting the Red, Green, and Blue video gain which are available on my monitor and I believe relatively common.

I also changed instances of the word 'brightness' to 'luminance', both to match the official VESA terminology in that MCCS document and to allow the short flag 'b' to refer to 'blue'. The help text has been updated to match these changes, README.md was updated to match the help text, and it looks like my Atom editor removed several instances of extra whitespace on blank lines.