### PR TITLE
Fix segv with arg processing

### DIFF
--- a/m1ddc.m
+++ b/m1ddc.m
@@ -79,6 +79,11 @@ int main(int argc, char** argv) {
 
         if ( !(strcmp(argv[s+1], "display")) ) {
 
+            if (argc == 4) {
+                returnText = @"No command specified. Please use `list` to list displays, or specify a display number to control\n";
+                goto cya;
+            }
+
             io_iterator_t iter;
             io_service_t service = 0;
             io_registry_entry_t root = IORegistryGetRootEntry(kIOMainPortDefault);


### PR DESCRIPTION
`./m1ddc display 2 input` would segv because it tried to read past the argv buffer.  This commit just outputs an error and returns.