### PR TITLE
Fix M4 MacBook Air

### DIFF
--- a/m1ddc.m
+++ b/m1ddc.m
@@ -108,8 +108,8 @@ int main(int argc, char** argv) {
             while ((service = IOIteratorNext(iter)) != MACH_PORT_NULL) {
                 io_name_t name;
                 IORegistryEntryGetName(service, name);
-                if ( !strcmp(name, "AppleCLCD2") ) {
 
+                if ((strlen(name) > strlen("dispext") && !memcmp(name, "dispext", strlen("dispext"))) || !strcmp(name, "DisplayPort")) {
                     CFStringRef edidUUID = IORegistryEntrySearchCFProperty(service, kIOServicePlane, edidUUIDKey, kCFAllocatorDefault, kIORegistryIterateRecursively);
 
                     if ( !(edidUUID == NULL) ) {


### PR DESCRIPTION
Registry entry names seem to be different on the M4 MacBook Air. This patch fixes it for me.  I'm on an M4 MBA + macOS 15.3.

Before this patch `display list` would return nothing.  After this patch I get the correct list.