### PR TITLE
Fix input address used for DDC write checksum calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 .objects/
 library/
 m1ddc
+
+# macOS related files
+.DS_Store

--- a/headers/i2c.h
+++ b/headers/i2c.h
@@ -38,7 +38,7 @@ typedef struct {
 DDCPacket	createDDCPacket(UInt8 attrCode);
 
 void		prepareDDCRead(UInt8 *data);
-void		prepareDDCWrite(UInt8 *data, UInt8 setValue);
+void		prepareDDCWrite(DDCPacket *packet, UInt8 setValue);
 
 IOReturn	performDDCWrite(IOAVServiceRef avService, DDCPacket *packet);
 IOReturn	performDDCRead(IOAVServiceRef avService, DDCPacket *packet);

--- a/sources/i2c.m
+++ b/sources/i2c.m
@@ -29,12 +29,14 @@ void prepareDDCRead(UInt8* data) {
 }
 
 // Prepare DDC packet for write
-void prepareDDCWrite(UInt8* data, UInt8 newValue) {
+void prepareDDCWrite(DDCPacket *packet, UInt8 newValue) {
+    UInt8* data = packet->data;
+
     data[0] = 0x84;
     data[1] = 0x03;
     data[3] = (newValue) >> 8;
     data[4] = newValue & 255;
-    data[5] = 0x6E ^ 0x51 ^ data[0] ^ data[1] ^ data[2] ^ data[3] ^ data[4];
+    data[5] = 0x6E ^ packet->inputAddr ^ data[0] ^ data[1] ^ data[2] ^ data[3] ^ data[4];
 }
 
 

--- a/sources/m1ddc.m
+++ b/sources/m1ddc.m
@@ -122,7 +122,7 @@ static DDCValue readingOperation(IOAVServiceRef avService, DDCPacket *packet) {
 // Function to handle the writing operation (set, chg)
 static int writingOperation(IOAVServiceRef avService, DDCPacket *packet, UInt8 newValue) {
 
-    prepareDDCWrite(packet->data, newValue);
+    prepareDDCWrite(packet, newValue);
 
     IOReturn err = performDDCWrite(avService, packet);
     if (err) {


### PR DESCRIPTION
This PR fixes input switching on the latest LG monitors like `UltraGear 34GS95QE-B`.

Related discussion: https://github.com/waydabber/BetterDisplay/discussions/4246