### PR TITLE
Add support for ASUS KVM (0xF3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ m1ddc display 10ACB8A0-0000-0000-1419-0104A2435078 set input 15`
                            DisplayPort 1: 15, DisplayPort 2: 16, HDMI 1: 17, HDMI 2: 18.
      kvm n               - Sets KVM order on certain Dell screens, possible values: TBD.
      kvm-switch          - Moves KVM to the next device on some Dells.
+     asus-kvm n          - Selects the USB upstream on certain ASUS screens (e.g. XG27UCDMG) when Auto KVM is disabled, possible values:
+                           USB-B: 2, USB-C: 3.
 
  get luminance           - Returns current luminance (if supported by the display).
      contrast            - Returns current contrast (if supported by the display).

--- a/headers/i2c.h
+++ b/headers/i2c.h
@@ -19,6 +19,7 @@
 # define PBP_INPUT	0xE8
 # define PBP		0xE9
 # define KVM		0xE7
+# define ASUS_KVM	0xF3
 
 # define DDC_WAIT			10000	// Depending on display this must be set to as high as 50000
 # define DDC_ITERATIONS		2		// Depending on display this must be set higher

--- a/sources/m1ddc.m
+++ b/sources/m1ddc.m
@@ -49,6 +49,8 @@ static void printUsage() {
     "     kvm n               - Sets KVM order on certain Dell screens, possible values:.\n"
     "                           USB1, USB2, USB3, USB4: 1728.\n"
     "                           Set 65280 to move KVM to the next device on some Dells.\n"
+    "     asus-kvm n          - Selects the USB upstream on certain ASUS screens (e.g. XG27UCDMG) when Auto KVM is disabled, possible values:\n"
+    "                           USB-B: 2, USB-C: 3.\n"
     "\n"
     " get luminance           - Returns current luminance (if supported by the display).\n"
     "     contrast            - Returns current contrast (if supported by the display).\n"
@@ -150,6 +152,7 @@ static UInt8 attrCodeFromCommand(char *command) {
     else if (STR_EQ(command, "pbp") || STR_EQ(command, "p")) { return PBP; }
     else if (STR_EQ(command, "pbp-input") || STR_EQ(command, "pi")) { return PBP_INPUT; }
     else if (STR_EQ(command, "kvm") || STR_EQ(command, "k")) { return KVM; }
+    else if (STR_EQ(command, "asus-kvm")) { return ASUS_KVM; }
     return 0x00;
 }
 

--- a/sources/m1ddc.m
+++ b/sources/m1ddc.m
@@ -46,7 +46,7 @@ static void printUsage() {
     "     pbp-input n         - Sets second PIP/PBP input on certain Dell screens, possible values:\n"
     "                           DisplayPort 1: 15, DisplayPort 2: 16, HDMI 1: 17, HDMI 2: 18.\n"
     "                           HDMI 1 and HDMI 2 and DisplayPort 1: 15953.\n"
-    "     kvm n               - Sets KVM order on certain Dell screens, possible values:.\n"
+    "     kvm n               - Sets KVM order on certain Dell screens, possible values:\n"
     "                           USB1, USB2, USB3, USB4: 1728.\n"
     "                           Set 65280 to move KVM to the next device on some Dells.\n"
     "     asus-kvm n          - Selects the USB upstream on certain ASUS screens (e.g. XG27UCDMG) when Auto KVM is disabled, possible values:\n"


### PR DESCRIPTION
Add a subcommand for ASUS KVMs.

I suspect the KVM VCP codes and implementation will differ across vendors, so I added a vendor-specific prefix (`asus-kvm` instead of `kvm-alt`, etc). Not sure if there is a better way to handle this.

Tested on the ASUS XG27UCDMG.