### PR TITLE
Fix max value byte offset in VCP reply parsing

### DIFF
--- a/sources/i2c.m
+++ b/sources/i2c.m
@@ -62,7 +62,7 @@ IOReturn performDDCWrite(IOAVServiceRef avService, DDCPacket *packet) {
 DDCValue convertI2CtoDDC(char *i2cBytes) {
     DDCValue displayAttr = {};
     NSData *i2cData = [NSData dataWithBytes:(const void *)i2cBytes length:(NSUInteger)11];
-    NSRange maxValueRange = {7, 2};
+    NSRange maxValueRange = {6, 2};
     uint16_t maxValue = 0;
     [[i2cData subdataWithRange:maxValueRange] getBytes:&maxValue length:sizeof(2)];
     displayAttr.maxValue = CFSwapInt16BigToHost(maxValue);


### PR DESCRIPTION
I noticed that my ASUS PA32QCV was reporting a different value when I would `m1ddc set luminance` versus `m1ddc get luminance`. I figured it was the monitor, since it has tons of DDC problems in general; but Claude was actually able to locate it as a bug in m1ddc. Confirmed this patch fixes the issue completely for me:

---

The VCP feature reply places the max value in bytes 6-7 and the current value in bytes 8-9. Reading max from offset 7 straddled the max low byte and the current value high byte, producing garbage for displays with 16-bit values (e.g. ASUS PA32QCV reports max luminance 36865 instead of 400).