### PR TITLE
Fix maximum value read from wrong byte offset in Get-VCP reply

### DIFF
--- a/sources/i2c.m
+++ b/sources/i2c.m
@@ -62,7 +62,9 @@ IOReturn performDDCWrite(IOAVServiceRef avService, DDCPacket *packet) {
 DDCValue convertI2CtoDDC(char *i2cBytes) {
     DDCValue displayAttr = {};
     NSData *i2cData = [NSData dataWithBytes:(const void *)i2cBytes length:(NSUInteger)11];
-    NSRange maxValueRange = {7, 2};
+    // DDC/CI "Get VCP Feature Reply": maximum value is in bytes [6..7] and the
+    // current value in bytes [8..9], both big-endian.
+    NSRange maxValueRange = {6, 2};
     uint16_t maxValue = 0;
     [[i2cData subdataWithRange:maxValueRange] getBytes:&maxValue length:sizeof(2)];
     displayAttr.maxValue = CFSwapInt16BigToHost(maxValue);


### PR DESCRIPTION
## The issue

When used with LG HDR QHD (LG QHD Ergo 27QN880-B) and MacBook Air M4 the `m1ddc` reports wrong maximum values. Each one comes back as **25600**:

```
$ m1ddc display 1 max luminance
25600
$ m1ddc display 1 max contrast
25600
$ m1ddc display 1 max volume
25600
```

That's seems wrong wrong — because monitor's own OSD menu maxes at 100 for all of these.
What made it suspicious is that `get` was perfectly fine the whole time (`get luminance` → 85, matching the OSD). 

So get *current* values worked, but reading *max* did not. 

## The problem

When you ask a monitor for a value over DDC, it replies with a fixed size packet. The two numbers we care about live here:

- the **maximum** is in bytes 6 and 7,
- the **current** value is in bytes 8 and 9.

(Both are big-endian — high byte first.)

I dumped the actual reply for `volume` to be sure:

```
6e 88 02 00 62 00 00 64 00 19 ab
                  ^^ ^^ ^^ ^^
                  6  7  8  9
```

- bytes 6–7 = `00 64` = **100**  → that's the max
- bytes 8–9 = `00 19` = **25**   → that's the current volume

That's exactly what OSD showed (volume 25, range 0–100).

Here's the bug - code reads the max starting at byte **7**, not byte 6:

```objc
NSRange maxValueRange = {7, 2};   // reads bytes 7 and 8
```

So instead of `00 64`, it grabs `64 00` (byte 7 + byte 8) → `0x6400` → **25600**.

It's just shifted over by one byte. The current-value read (`{8, 2}`) was right, which is exactly why `get` worked and only `max` was broken.

Looks like a small regression from PR #54 ("Allow to read/write 2 byte values"). 

Before that, the read was a single byte (`{7, 1}`), and that *happened* to work: maximums are almost always ≤ 255, so the
low byte at offset 7 was the entire value. 

After #54 widened the read to 2 bytes, it should have also moved the start back to offset 6 to include the high byte. It
moved the width but not the offset, so byte 7 became the high byte and the value blew up.

## The result

Same monitor, OSD = brightness 85, contrast 70, volume 25

```
$ m1ddc display 1 max luminance
100
$ m1ddc display 1 max contrast
100
$ m1ddc display 1 max volume
100
$ m1ddc display 1 get luminance
85
```