### PR TITLE
Add DDC support for M1 built-in HDMI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # m1ddc
 
-This little tool controls external displays (connected via USB-C/DisplayPort Alt Mode) using DDC/CI on Apple Silicon Macs. Useful to embed in various scripts.
+This little tool controls external displays using DDC/CI on Apple Silicon Macs, including displays connected through USB-C/DisplayPort Alt Mode and supported built-in HDMI ports. Useful to embed in various scripts.
 
 For a much more advanced CLI solution check out [BetterDisplay's CLI capabilities](https://github.com/waydabber/BetterDisplay/wiki/Integration-features,-CLI).
 
 > [!WARNING]
-> Please note that this tool does not support the built-in HDMI port of M1 and entry level M2 Macs. This tool does not support Intel Macs. You can use [BetterDisplay](https://github.com/waydabber/BetterDisplay#readme) for free DDC control on all Macs and all ports.
+> Please note that this tool does not support Intel Macs. You can use [BetterDisplay](https://github.com/waydabber/BetterDisplay#readme) for free DDC control on all Macs and all ports.
 
 ## Prerequisites
 

--- a/headers/i2c.h
+++ b/headers/i2c.h
@@ -22,6 +22,7 @@
 
 # define DDC_WAIT			10000	// Depending on display this must be set to as high as 50000
 # define DDC_ITERATIONS		2		// Depending on display this must be set higher
+# define DDC_MCDP_READ_WAIT	50000	// 10 ms returned empty MCDP29xx replies in testing
 # define DDC_BUFFER_SIZE	256
 
 
@@ -43,6 +44,8 @@ void		prepareDDCWrite(DDCPacket *packet, UInt16 setValue);
 
 IOReturn	performDDCWrite(IOAVServiceRef avService, DDCPacket *packet);
 IOReturn	performDDCRead(IOAVServiceRef avService, DDCPacket *packet);
+IOReturn	performDDCWriteAtChipAddress(IOAVServiceRef avService, UInt32 chipAddress, DDCPacket *packet);
+IOReturn	performDDCReadAtChipAddress(IOAVServiceRef avService, UInt32 chipAddress, DDCPacket *packet);
 
 DDCValue	convertI2CtoDDC(char *i2cBytes);
 

--- a/headers/ioregistry.h
+++ b/headers/ioregistry.h
@@ -12,6 +12,15 @@
 // IOAVServiceRef is a private class, so we need to define it here
 typedef CFTypeRef IOAVServiceRef;
 
+# define DDC_CHIP_ADDRESS_DEFAULT  0x37
+# define DDC_CHIP_ADDRESS_MCDP29XX 0xB7
+
+typedef struct
+{
+    IOAVServiceRef service;
+    UInt32 chipAddress;
+} DDCTransport;
+
 // Base structure for display infos
 typedef struct
 {
@@ -33,6 +42,7 @@ DisplayInfos*   selectDisplay(DisplayInfos *displays, int connectedDisplays, cha
 
 IOAVServiceRef  getDefaultDisplayAVService();
 IOAVServiceRef  getDisplayAVService(DisplayInfos* displayInfos);
+DDCTransport    getDisplayDDCTransport(DisplayInfos* displayInfos);
 
 // External functions
 extern IOAVServiceRef   IOAVServiceCreate(CFAllocatorRef allocator);

--- a/sources/i2c.m
+++ b/sources/i2c.m
@@ -40,22 +40,30 @@ void prepareDDCWrite(DDCPacket *packet, UInt16 newValue) {
 }
 
 
-IOReturn performDDCRead(IOAVServiceRef avService, DDCPacket *packet) {
+IOReturn performDDCReadAtChipAddress(IOAVServiceRef avService, UInt32 chipAddress, DDCPacket *packet) {
     memset(packet->data, 0, sizeof(UInt8) * DDC_BUFFER_SIZE);
-    usleep(DDC_WAIT);
-    return IOAVServiceReadI2C(avService, 0x37, packet->inputAddr, packet->data, 12);
+    usleep(chipAddress == DDC_CHIP_ADDRESS_MCDP29XX ? DDC_MCDP_READ_WAIT : DDC_WAIT);
+    return IOAVServiceReadI2C(avService, chipAddress, packet->inputAddr, packet->data, 12);
 }
 
-IOReturn performDDCWrite(IOAVServiceRef avService, DDCPacket *packet) {
+IOReturn performDDCWriteAtChipAddress(IOAVServiceRef avService, UInt32 chipAddress, DDCPacket *packet) {
     IOReturn ret;
 
     for (int i = 0; i < DDC_ITERATIONS; ++i) {
         usleep(DDC_WAIT);
-        if ((ret = IOAVServiceWriteI2C(avService, 0x37, packet->inputAddr, packet->data, getBytesUsed(packet->data)))) {
+        if ((ret = IOAVServiceWriteI2C(avService, chipAddress, packet->inputAddr, packet->data, getBytesUsed(packet->data)))) {
             return ret;
         }
     }
     return ret;
+}
+
+IOReturn performDDCRead(IOAVServiceRef avService, DDCPacket *packet) {
+    return performDDCReadAtChipAddress(avService, DDC_CHIP_ADDRESS_DEFAULT, packet);
+}
+
+IOReturn performDDCWrite(IOAVServiceRef avService, DDCPacket *packet) {
+    return performDDCWriteAtChipAddress(avService, DDC_CHIP_ADDRESS_DEFAULT, packet);
 }
 
 

--- a/sources/ioregistry.m
+++ b/sources/ioregistry.m
@@ -11,6 +11,30 @@ static CFTypeRef getCFStringRef(io_service_t service, char* key) {
     return IORegistryEntrySearchCFProperty(service, kIOServicePlane, cfstring, kCFAllocatorDefault, kIORegistryIterateRecursively);
 }
 
+static Boolean isMCDP29XXProxy(io_service_t proxy) {
+    io_registry_entry_t parent = MACH_PORT_NULL;
+    if (IORegistryEntryGetParentEntry(proxy, kIOServicePlane, &parent) != KERN_SUCCESS) {
+        return false;
+    }
+
+    Boolean isMCDP29XX = false;
+    CFTypeRef providerClass = IORegistryEntryCreateCFProperty(
+        parent,
+        CFSTR("EPICProviderClass"),
+        kCFAllocatorDefault,
+        0
+    );
+    if (providerClass != NULL && CFGetTypeID(providerClass) == CFStringGetTypeID()) {
+        isMCDP29XX = CFStringCompare(providerClass, CFSTR("AppleDCPMCDP29XX"), 0) == kCFCompareEqualTo;
+    }
+
+    if (providerClass != NULL) {
+        CFRelease(providerClass);
+    }
+    IOObjectRelease(parent);
+    return isMCDP29XX;
+}
+
 CGDisplayCount getOnlineDisplayInfos(DisplayInfos* displayInfos) {
     // Getting online display list and count
     CGDisplayCount screenCount;
@@ -159,38 +183,84 @@ IOAVServiceRef getDefaultDisplayAVService() {
     return IOAVServiceCreate(kCFAllocatorDefault);
 }
 
-IOAVServiceRef getDisplayAVService(DisplayInfos* displayInfos) {
+DDCTransport getDisplayDDCTransport(DisplayInfos* displayInfos) {
 
-    IOAVServiceRef avService = NULL;
-    io_service_t service = 0;
-    io_iterator_t iter;
-
-    // Creating IORegistry iterator
-    if (getIORegistryRootIterator(&iter) != KERN_SUCCESS) {
-        return NULL;
+    DDCTransport transport = {
+        .service = NULL,
+        .chipAddress = DDC_CHIP_ADDRESS_DEFAULT,
+    };
+    if (displayInfos == NULL || displayInfos->adapter == MACH_PORT_NULL) {
+        return transport;
     }
 
-    CFStringRef externalAVServiceLocation = CFStringCreateWithCString(kCFAllocatorDefault, "External", kCFStringEncodingASCII);
+    uint64_t selectedAdapterID;
+    if (IORegistryEntryGetRegistryEntryID(displayInfos->adapter, &selectedAdapterID) != KERN_SUCCESS) {
+        return transport;
+    }
+
+    // Creating IORegistry iterator
+    io_iterator_t iter;
+    if (getIORegistryRootIterator(&iter) != KERN_SUCCESS) {
+        return transport;
+    }
+
+    Boolean framebufferMatchesDisplay = false;
+    io_service_t service;
 
 	// Iterating through IORegistry
     while ((service = IOIteratorNext(iter)) != MACH_PORT_NULL) {
-        io_string_t servicePath;
-        IORegistryEntryGetPath(service, kIOServicePlane, servicePath);
-        // Searching for DCPAVServiceProxy with the same location as the display
-        if (displayInfos->ioLocation != NULL && STR_EQ(servicePath, displayInfos->ioLocation.UTF8String)) {
-            while ((service = IOIteratorNext(iter)) != MACH_PORT_NULL) {
-                io_name_t name;
-                IORegistryEntryGetName(service, name);
-                if (STR_EQ(name, "DCPAVServiceProxy")) {
-                    // Creating IOAVServiceRef from DCPAVServiceProxy
-                    avService = IOAVServiceCreateWithService(kCFAllocatorDefault, service);
-                    CFStringRef location = getCFStringRef(service, "Location");
-                    if (location != NULL && avService != NULL && !CFStringCompare(externalAVServiceLocation, location, 0)) {
-                        return avService;
-                    }
-                }
-            }
+        if (IOObjectConformsTo(service, "IOMobileFramebuffer")) {
+            uint64_t framebufferID;
+            framebufferMatchesDisplay =
+                IORegistryEntryGetRegistryEntryID(service, &framebufferID) == KERN_SUCCESS &&
+                framebufferID == selectedAdapterID;
+            IOObjectRelease(service);
+            continue;
         }
+
+        // Searching for DCPAVServiceProxy associated with the selected display
+        io_name_t name;
+        IORegistryEntryGetName(service, name);
+        if (!framebufferMatchesDisplay || !STR_EQ(name, "DCPAVServiceProxy")) {
+            IOObjectRelease(service);
+            continue;
+        }
+
+        // Creating IOAVServiceRef from DCPAVServiceProxy
+        IOAVServiceRef avService = IOAVServiceCreateWithService(kCFAllocatorDefault, service);
+        if (avService == NULL) {
+            IOObjectRelease(service);
+            continue;
+        }
+
+        CFStringRef location = getCFStringRef(service, "Location");
+        Boolean isExternal = location != NULL &&
+            CFGetTypeID(location) == CFStringGetTypeID() &&
+            CFStringCompare(CFSTR("External"), location, 0) == kCFCompareEqualTo;
+        if (location != NULL) {
+            CFRelease(location);
+        }
+
+        if (!isExternal) {
+            CFRelease(avService);
+            IOObjectRelease(service);
+            continue;
+        }
+
+        transport.service = avService;
+        // MCDP29xx routes DDC through chip address 0xB7.
+        transport.chipAddress = isMCDP29XXProxy(service)
+            ? DDC_CHIP_ADDRESS_MCDP29XX
+            : DDC_CHIP_ADDRESS_DEFAULT;
+        IOObjectRelease(service);
+        IOObjectRelease(iter);
+        return transport;
     }
-    return NULL;
+
+    IOObjectRelease(iter);
+    return transport;
+}
+
+IOAVServiceRef getDisplayAVService(DisplayInfos* displayInfos) {
+    return getDisplayDDCTransport(displayInfos).service;
 }

--- a/sources/m1ddc.m
+++ b/sources/m1ddc.m
@@ -15,8 +15,8 @@ static void writeToStdOut(NSString *text) {
 }
 
 static void printUsage() {
-    writeToStdOut(@"Controls volume, luminance (brightness), contrast, color gain, input of an external Display connected via USB-C (DisplayPort Alt Mode) over DDC on an Apple Silicon Mac.\n"
-    "Displays attached via the built-in HDMI port of M1 or entry level M2 Macs are not supported.\n"
+    writeToStdOut(@"Controls volume, luminance (brightness), contrast, color gain, and input of an external display over DDC on an Apple Silicon Mac.\n"
+    "Supports USB-C/DisplayPort Alt Mode and supported built-in HDMI ports.\n"
     "\n"
     "Usage examples:\n"
     "\n"
@@ -100,12 +100,12 @@ static void printDisplayInfos(DisplayInfos *display, int nbDisplays, bool detail
 }
 
 // Function to handle the reading operation (get, max, chg)
-static DDCValue readingOperation(IOAVServiceRef avService, DDCPacket *packet) {
+static DDCValue readingOperation(DDCTransport *transport, DDCPacket *packet) {
     DDCValue dummyAttr = {-1, -1};
 
     prepareDDCRead(packet->data);
 
-    IOReturn err = performDDCWrite(avService, packet);
+    IOReturn err = performDDCWriteAtChipAddress(transport->service, transport->chipAddress, packet);
     if (err) {
         writeToStdOut([NSString stringWithFormat:@"DDC communication failure: %s\n", mach_error_string(err)]);
         return dummyAttr;
@@ -114,7 +114,7 @@ static DDCValue readingOperation(IOAVServiceRef avService, DDCPacket *packet) {
     DDCPacket readPacket = {};
     readPacket.inputAddr = packet->inputAddr;
 
-    err = performDDCRead(avService, &readPacket);
+    err = performDDCReadAtChipAddress(transport->service, transport->chipAddress, &readPacket);
     if (err) {
         writeToStdOut([NSString stringWithFormat:@"DDC communication failure: %s\n", mach_error_string(err)]);
         return dummyAttr;
@@ -124,11 +124,11 @@ static DDCValue readingOperation(IOAVServiceRef avService, DDCPacket *packet) {
 }
 
 // Function to handle the writing operation (set, chg)
-static int writingOperation(IOAVServiceRef avService, DDCPacket *packet, UInt16 newValue) {
+static int writingOperation(DDCTransport *transport, DDCPacket *packet, UInt16 newValue) {
 
     prepareDDCWrite(packet, newValue);
 
-    IOReturn err = performDDCWrite(avService, packet);
+    IOReturn err = performDDCWriteAtChipAddress(transport->service, transport->chipAddress, packet);
     if (err) {
         writeToStdOut([NSString stringWithFormat:@"DDC communication failure: %s\n", mach_error_string(err)]);
         return 1;
@@ -215,17 +215,42 @@ int main(int argc, char** argv) {
         argc -= 2;
     }
 
-    IOAVServiceRef avService;
+    DDCTransport transport = {
+        .service = NULL,
+        .chipAddress = DDC_CHIP_ADDRESS_DEFAULT,
+    };
 
-    // If there is no display selected, we'll use the default display
+    // For unqualified commands, use the main display's matched service only
+    // when it is positively identified as MCDP29xx. Otherwise preserve the
+    // legacy default IOAVServiceCreate()/0x37 behavior.
     if (selectedDisplay == NULL) {
-        selectedDisplay = displayInfos;
-        avService = getDefaultDisplayAVService();
+        int connectedDisplays = getOnlineDisplayInfos(displayInfos);
+        CGDirectDisplayID mainDisplayID = CGMainDisplayID();
+
+        for (int i = 0; i < connectedDisplays; ++i) {
+            if (displayInfos[i].id != mainDisplayID) {
+                continue;
+            }
+
+            DDCTransport mainTransport = getDisplayDDCTransport(displayInfos + i);
+            if (mainTransport.service != NULL && mainTransport.chipAddress == DDC_CHIP_ADDRESS_MCDP29XX) {
+                selectedDisplay = displayInfos + i;
+                transport = mainTransport;
+            } else if (mainTransport.service != NULL) {
+                CFRelease(mainTransport.service);
+            }
+            break;
+        }
+
+        if (transport.service == NULL) {
+            selectedDisplay = displayInfos;
+            transport.service = getDefaultDisplayAVService();
+        }
     } else {
-        avService = getDisplayAVService(selectedDisplay);
+        transport = getDisplayDDCTransport(selectedDisplay);
     }
 
-    if (avService == NULL) {
+    if (transport.service == NULL) {
         writeToStdOut(@"Could not find a suitable external display.\n");
         return EXIT_FAILURE;
     }
@@ -251,7 +276,7 @@ int main(int argc, char** argv) {
 
     // Reading current
     if (!STR_EQ(argv[0], "set")) {
-        displayAttr = readingOperation(avService, &packet);
+        displayAttr = readingOperation(&transport, &packet);
         if (displayAttr.curValue == -1) {
             return EXIT_FAILURE;
         }
@@ -275,7 +300,7 @@ int main(int argc, char** argv) {
 
         UInt16 writeValue = computeAttributeValue(argv[0], argv[2], displayAttr);
 
-        if (writingOperation(avService, &packet, writeValue)) {
+        if (writingOperation(&transport, &packet, writeValue)) {
             return EXIT_FAILURE;
         }
         writeToStdOut([NSString stringWithFormat:@"Writing %i\n", writeValue]);


### PR DESCRIPTION
## Summary

Adds DDC support for displays connected through the M1 Mac mini's built-in HDMI port.

- Detects `AppleDCPMCDP29XX` display proxies
- Uses chip address `0xB7` for MCDP29xx while preserving `0x37` for existing transports
- Associates the DDC proxy with the selected display
- Supports both explicitly selected displays and unqualified commands targeting the main display
- Preserves the legacy service and timing behavior for non-MCDP displays
- Uses a longer read delay for MCDP29xx, required during hardware testing


## Testing

Tested on an M1 Mac mini with an LG HDR 4K display connected through built-in HDMI:

- Built the CLI with `make`
- Built the static library with `make lib`
- Read brightness using both the default command and `display 1`
- Changed brightness from 30 to 29 and restored it to 30
- Verified writes work without additional retry logic